### PR TITLE
Fixed FastPriorityQueue index and added the remove() function

### DIFF
--- a/benchmark/ExtractPriorityQueue.php
+++ b/benchmark/ExtractPriorityQueue.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendBench\Stdlib;
+
+use Athletic\AthleticEvent;
+use Zend\Stdlib\FastPriorityQueue;
+use Zend\Stdlib\PriorityQueue;
+use Zend\Stdlib\SplPriorityQueue;
+
+class ExtractPriorityQueue extends AthleticEvent
+{
+    public function classSetUp()
+    {
+        $this->splPriorityQueue  = new SplPriorityQueue();
+        $this->fastPriorityQueue = new FastPriorityQueue();
+        $this->priorityQueue     = new PriorityQueue();
+
+        for ($i = 0; $i < 5000; $i += 1) {
+            $priority = rand(1, 100);
+            $this->splPriorityQueue->insert('foo', $priority);
+            $this->fastPriorityQueue->insert('foo', $priority);
+            $this->priorityQueue->insert('foo', $priority);
+        }
+    }
+
+    /**
+     * @iterations 5000
+     */
+    public function extractSplPriorityQueue()
+    {
+        $this->splPriorityQueue->extract();
+    }
+
+    /**
+     * @iterations 5000
+     */
+    public function extractPriorityQueue()
+    {
+        $this->priorityQueue->extract();
+    }
+
+    /**
+     * @iterations 5000
+     */
+    public function extractFastPriorityQueue()
+    {
+        $this->fastPriorityQueue->extract();
+    }
+}

--- a/benchmark/InsertPriorityQueue.php
+++ b/benchmark/InsertPriorityQueue.php
@@ -14,20 +14,13 @@ use Zend\Stdlib\FastPriorityQueue;
 use Zend\Stdlib\PriorityQueue;
 use Zend\Stdlib\SplPriorityQueue;
 
-class PriorityQueueBenchmark extends AthleticEvent
+class InsertPriorityQueue extends AthleticEvent
 {
     public function classSetUp()
     {
         $this->splPriorityQueue  = new SplPriorityQueue();
         $this->fastPriorityQueue = new FastPriorityQueue();
         $this->priorityQueue     = new PriorityQueue();
-
-        for ($i = 0; $i < 5000; $i += 1) {
-            $priority = rand(1, 100);
-            $this->splPriorityQueue->insert('foo', $priority);
-            $this->fastPriorityQueue->insert('foo', $priority);
-            $this->priorityQueue->insert('foo', $priority);
-        }
     }
 
     /**
@@ -41,14 +34,6 @@ class PriorityQueueBenchmark extends AthleticEvent
     /**
      * @iterations 5000
      */
-    public function extractSplPriorityQueue()
-    {
-        $this->splPriorityQueue->extract();
-    }
-
-    /**
-     * @iterations 5000
-     */
     public function insertPriorityQueue()
     {
         $this->priorityQueue->insert('foo', rand(1, 100));
@@ -57,24 +42,8 @@ class PriorityQueueBenchmark extends AthleticEvent
     /**
      * @iterations 5000
      */
-    public function extractPriorityQueue()
-    {
-        $this->priorityQueue->extract();
-    }
-    
-    /**
-     * @iterations 5000
-     */
     public function insertFastPriorityQueue()
     {
         $this->fastPriorityQueue->insert('foo', rand(1, 100));
-    }
-
-    /**
-     * @iterations 5000
-     */
-    public function extractFastPriorityQueue()
-    {
-        $this->fastPriorityQueue->extract();
     }
 }

--- a/benchmark/RemovePriorityQueue.php
+++ b/benchmark/RemovePriorityQueue.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendBench\Stdlib;
+
+use Athletic\AthleticEvent;
+use Zend\Stdlib\FastPriorityQueue;
+use Zend\Stdlib\PriorityQueue;
+
+class RemovePriorityQueue extends AthleticEvent
+{
+    public function classSetUp()
+    {
+        $this->fastPriorityQueue = new FastPriorityQueue();
+        $this->priorityQueue     = new PriorityQueue();
+
+        for ($i = 0; $i < 1000; $i += 1) {
+            $priority = rand(1, 100);
+            $this->fastPriorityQueue->insert('foo', $priority);
+            $this->priorityQueue->insert('foo', $priority);
+        }
+    }
+
+    /**
+     * @iterations 1000
+     */
+    public function removePriorityQueue()
+    {
+        $this->priorityQueue->remove('foo');
+    }
+
+    /**
+     * @iterations 1000
+     */
+    public function removeFastPriorityQueue()
+    {
+        $this->fastPriorityQueue->remove('foo');
+    }
+}

--- a/test/FastPriorityQueueTest.php
+++ b/test/FastPriorityQueueTest.php
@@ -130,13 +130,13 @@ class FastPriorityQueueTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($this->queue->valid());
     }
 
-    public function testNoRewindOperation()
+    public function testRewindOperation()
     {
         $this->assertEquals(0, $this->queue->key());
         $this->queue->next();
         $this->assertEquals(1, $this->queue->key());
         $this->queue->rewind();
-        $this->assertEquals(1, $this->queue->key());
+        $this->assertEquals(0, $this->queue->key());
     }
 
     public function testSetExtractFlag()
@@ -186,5 +186,44 @@ class FastPriorityQueueTest extends \PHPUnit_Framework_TestCase
             $this->assertTrue($this->queue->hasPriority($priority));
         }
         $this->assertFalse($this->queue->hasPriority(10000));
+    }
+
+    public function testCanRemoveItemFromQueue()
+    {
+        $this->assertTrue($this->queue->remove('test5'));
+        $tot = count($this->getDataPriorityQueue()) - 1;
+        $this->assertEquals($this->queue->count(), $tot);
+        $this->assertEquals(count($this->queue), $tot);
+        $expected = ['test1', 'test2', 'test3', 'test4', 'test6'];
+        $test = [];
+        foreach ($this->queue as $item) {
+            $test[] = $item;
+        }
+        $this->assertEquals($expected, $test);
+    }
+
+    public function testRemoveOnlyTheFirstOccurenceFromQueue()
+    {
+        $data = $this->getDataPriorityQueue();
+        $this->queue->insert('test2', $data['test2']);
+        $tot = count($this->getDataPriorityQueue()) + 1;
+        $this->assertEquals($this->queue->count(), $tot);
+        $this->assertEquals(count($this->queue), $tot);
+
+        $expected = ['test1', 'test2', 'test2', 'test3', 'test4', 'test5', 'test6'];
+        $test = [];
+        foreach ($this->queue as $item) {
+            $test[] = $item;
+        }
+        $this->assertEquals($expected, $test);
+
+        $this->assertTrue($this->queue->remove('test2'));
+        $this->assertEquals($this->queue->count(), $tot - 1);
+        $this->assertEquals(count($this->queue), $tot - 1);
+        $test = [];
+        foreach ($this->queue as $item) {
+            $test[] = $item;
+        }
+        $this->assertEquals($this->expected, $test);
     }
 }


### PR DESCRIPTION
This PR fixes an issue with the internal index of the `FastPriorityQueue` and add the `remove()` function. This function acts like the `remove` method of the `Zend\Stdlib\PriorityQueue` but the performance are much faster (see benchmark below).

Moreover, I divided the benchmarks into separate files and I added the remove test. Here is reported a test using an Intel Core i5-2500 at 3.30GHz with 8 Gb of RAM running Ubuntu Linux 14.04 and PHP 5.5.9:
```
ZendBench\Stdlib\ExtractPriorityQueue
    Method Name                Iterations    Average Time      Ops/second
    ------------------------  ------------  --------------    -------------
    extractSplPriorityQueue : [5,000     ] [0.0000028611183] [349,513.68288]
    extractPriorityQueue    : [5,000     ] [0.0000032114506] [311,385.76668]
    extractFastPriorityQueue: [5,000     ] [0.0000013429165] [744,647.94234]


ZendBench\Stdlib\InsertPriorityQueue
    Method Name               Iterations    Average Time      Ops/second
    -----------------------  ------------  --------------    -------------
    insertSplPriorityQueue : [5,000     ] [0.0000019140244] [522,459.39213]
    insertPriorityQueue    : [5,000     ] [0.0000052907467] [189,009.23798]
    insertFastPriorityQueue: [5,000     ] [0.0000008188248] [1,221,262.52038]


ZendBench\Stdlib\RemovePriorityQueue
    Method Name               Iterations    Average Time      Ops/second
    -----------------------  ------------  --------------    -------------
    removePriorityQueue    : [1,000     ] [0.0008117966652] [1,231.83556]
    removeFastPriorityQueue: [1,000     ] [0.0000023496151] [425,601.62354]

```
