### PR TITLE
Do not raise error on rewind

### DIFF
--- a/src/FastPriorityQueue.php
+++ b/src/FastPriorityQueue.php
@@ -233,7 +233,7 @@ class FastPriorityQueue implements Iterator, Countable, Serializable
     public function rewind()
     {
         $this->subPriorities = $this->priorities;
-        $this->maxPriority   = max($this->priorities);
+        $this->maxPriority   = empty($this->priorities) ? 0 : max($this->priorities);
         $this->index         = 0;
         $this->subIndex      = 0;
     }

--- a/test/FastPriorityQueueTest.php
+++ b/test/FastPriorityQueueTest.php
@@ -226,4 +226,16 @@ class FastPriorityQueueTest extends \PHPUnit_Framework_TestCase
         }
         $this->assertEquals($this->expected, $test);
     }
+
+    public function testRewindShouldNotRaiseErrorWhenQueueIsEmpty()
+    {
+        $queue = new FastPriorityQueue();
+        $this->assertTrue($queue->isEmpty());
+
+        set_error_handler(function ($errno, $errstr) {
+            $this->fail(sprintf('Error was raised by rewind() operation: %s', $errstr));
+        }, E_WARNING);
+        $queue->rewind();
+        restore_error_handler();
+    }
 }


### PR DESCRIPTION
Demonstrates an `E_WARNING` raised in `rewind()` when the queue is
empty, and provides a fix.

Discovered when testing develop branch against Apigility.