### PR TITLE
Fix issue with iterative removal

### DIFF
--- a/src/FastPriorityQueue.php
+++ b/src/FastPriorityQueue.php
@@ -135,7 +135,8 @@ class FastPriorityQueue implements Iterator, Countable, Serializable
         $this->rewind();
         while ($this->valid()) {
             if (current($this->values[$this->maxPriority]) === $datum) {
-                unset($this->values[$this->maxPriority][$this->subIndex]);
+                $index = key($this->values[$this->maxPriority]);
+                unset($this->values[$this->maxPriority][$index]);
                 --$this->count;
                 return true;
             }

--- a/test/FastPriorityQueueTest.php
+++ b/test/FastPriorityQueueTest.php
@@ -238,4 +238,51 @@ class FastPriorityQueueTest extends \PHPUnit_Framework_TestCase
         $queue->rewind();
         restore_error_handler();
     }
+
+    public function testRemoveShouldFindItemEvenIfMultipleItemsAreInQueue()
+    {
+        $prototype = function ($e) {
+        };
+
+        $queue = new FastPriorityQueue();
+        $this->assertTrue($queue->isEmpty());
+
+        $listeners = [];
+        for ($i = 0; $i < 5; $i += 1) {
+            $listeners[] = $listener = clone $prototype;
+            $queue->insert($listener, 1);
+        }
+
+        $remove   = array_rand(array_keys($listeners));
+        $listener = $listeners[$remove];
+
+        $this->assertTrue($queue->contains($listener));
+        $this->assertTrue($queue->remove($listener));
+        $this->assertFalse($queue->contains($listener));
+    }
+
+    public function testIterativelyRemovingItemsShouldRemoveAllItems()
+    {
+        $prototype = function ($e) {
+        };
+
+        $queue = new FastPriorityQueue();
+        $this->assertTrue($queue->isEmpty());
+
+        $listeners = [];
+        for ($i = 0; $i < 5; $i += 1) {
+            $listeners[] = $listener = clone $prototype;
+            $queue->insert($listener, 1);
+        }
+
+        for ($i = 0; $i < 5; $i += 1) {
+            $listener = $listeners[$i];
+            $queue->remove($listener);
+        }
+
+        for ($i = 0; $i < 5; $i += 1) {
+            $listener = $listeners[$i];
+            $this->assertFalse($queue->contains($listener), sprintf('Listener %s remained in queue', $i));
+        }
+    }
 }


### PR DESCRIPTION
In testing zend-eventmanager, I discovered a race condition with the following:

```php
while ($queue->contains($listener)) {
    $queue->remove($listener);
}
```

In debugging, I determined that while `remove()` was correctly identifying that it had the datum, it was not using the correct index in the value array to unset it, which would leave it in place. Modifying the code to use `key()` on the values array allows it to work as expected.