### PR TITLE
Mark CallbackHandler as deprecated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Deprecated
 
-- Nothing.
+- [#35](https://github.com/zendframework/zend-stdlib/pull/35) deprecates
+  `Zend\Stdlib\CallbackHandler`, as the one component that used it,
+  zend-eventmanager, will no longer depend on it starting in v3.
 
 ### Removed
 

--- a/src/CallbackHandler.php
+++ b/src/CallbackHandler.php
@@ -17,6 +17,11 @@ use ReflectionClass;
  * A handler for an event, event, filterchain, etc. Abstracts PHP callbacks,
  * primarily to allow for lazy-loading and ensuring availability of default
  * arguments (currying).
+ *
+ * This was primarily used in zend-eventmanager for managing listeners; as that
+ * component removes its usage of this class for v3, it is deprecated.
+ *
+ * @deprecated as of v2.7.4.
  */
 class CallbackHandler
 {


### PR DESCRIPTION
Deprecating starting with 2.7.4, as zend-eventmanager no longer requires it with v3.