### PR TITLE
ArrayUtils::inArray always call strict version of in_array

### DIFF
--- a/src/ArrayUtils.php
+++ b/src/ArrayUtils.php
@@ -199,7 +199,7 @@ abstract class ArrayUtils
                 }
             }
         }
-        return in_array($needle, $haystack, $strict);
+        return in_array($needle, $haystack, true);
     }
 
     /**

--- a/test/ArrayUtilsTest.php
+++ b/test/ArrayUtilsTest.php
@@ -542,4 +542,15 @@ class ArrayUtilsTest extends TestCase
     {
         ArrayUtils::filter([], "INVALID");
     }
+
+    /**
+     * @see https://github.com/zendframework/zend-stdlib/issues/41
+     */
+    public function testInArrayFunctionCallShouldAlwaysBeStrictToPreventStringMatchingIssues()
+    {
+        $needle = '1.10';
+        $haystack = ['1.1'];
+
+        $this->assertFalse(ArrayUtils::inArray($needle, $haystack));
+    }
 }


### PR DESCRIPTION
Proposed fix for #41.  