### PR TITLE
Backwards compatibility for hydrators

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,6 @@ matrix:
     - php: 7
     - php: hhvm 
   allow_failures:
-    - php: 7
     - php: hhvm
 
 notifications:
@@ -36,7 +35,7 @@ before_install:
   - if [[ $EXECUTE_TEST_COVERALLS == 'true' ]]; then composer require --dev --no-update satooshi/php-coveralls ; fi
 
 install:
-  - travis_retry composer install --no-interaction --ignore-platform-reqs
+  - COMPOSER_ROOT_VERSION=2.7.99 travis_retry composer install --no-interaction --ignore-platform-reqs
 
 script:
   - if [[ $EXECUTE_TEST_COVERALLS == 'true' ]]; then ./vendor/bin/phpunit --coverage-clover clover.xml ; fi

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         }
     },
     "require": {
-        "php": ">=5.5",
+        "php": "^5.5 || ^7.0",
         "zendframework/zend-hydrator": "~1.0"
     },
     "require-dev": {
@@ -37,8 +37,9 @@
     "prefer-stable": true,
     "extra": {
         "branch-alias": {
-            "dev-master": "2.7-dev",
-            "dev-develop": "2.8-dev"
+            "dev-release-2.7": "2.7-dev",
+            "dev-master": "3.0-dev",
+            "dev-develop": "3.1-dev"
         }
     },
     "autoload-dev": {

--- a/src/Hydrator/DelegatingHydratorFactory.php
+++ b/src/Hydrator/DelegatingHydratorFactory.php
@@ -9,11 +9,18 @@
 
 namespace Zend\Stdlib\Hydrator;
 
-use Zend\Hydrator\DelegatingHydratorFactory as BaseDelegatingHydratorFactory;
+use Zend\ServiceManager\FactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
 
 /**
  * @deprecated Use Zend\Hydrator\DelegatingHydratorFactory from zendframework/zend-hydrator instead.
  */
-class DelegatingHydratorFactory extends BaseDelegatingHydratorFactory
+class DelegatingHydratorFactory implements FactoryInterface
 {
+    public function createService(ServiceLocatorInterface $serviceLocator)
+    {
+        // Assume that this factory is registered with the HydratorManager,
+        // and just pass it directly on.
+        return new DelegatingHydrator($serviceLocator);
+    }
 }

--- a/src/Hydrator/HydratorPluginManager.php
+++ b/src/Hydrator/HydratorPluginManager.php
@@ -20,4 +20,33 @@ use Zend\Hydrator\HydratorPluginManager as BaseHydratorPluginManager;
  */
 class HydratorPluginManager extends BaseHydratorPluginManager
 {
+    /**
+     * Default aliases
+     *
+     * @var array
+     */
+    protected $aliases = [
+        'delegatinghydrator' => 'Zend\Stdlib\Hydrator\DelegatingHydrator',
+    ];
+
+    /**
+     * Default set of adapters
+     *
+     * @var array
+     */
+    protected $invokableClasses = [
+        'arrayserializable' => 'Zend\Stdlib\Hydrator\ArraySerializable',
+        'classmethods'      => 'Zend\Stdlib\Hydrator\ClassMethods',
+        'objectproperty'    => 'Zend\Stdlib\Hydrator\ObjectProperty',
+        'reflection'        => 'Zend\Stdlib\Hydrator\Reflection'
+    ];
+
+    /**
+     * Default factory-based adapters
+     *
+     * @var array
+     */
+    protected $factories = [
+        'Zend\Stdlib\Hydrator\DelegatingHydrator' => 'Zend\Stdlib\Hydrator\DelegatingHydratorFactory',
+    ];
 }

--- a/src/Hydrator/HydratorPluginManager.php
+++ b/src/Hydrator/HydratorPluginManager.php
@@ -48,5 +48,6 @@ class HydratorPluginManager extends BaseHydratorPluginManager
      */
     protected $factories = [
         'Zend\Stdlib\Hydrator\DelegatingHydrator' => 'Zend\Stdlib\Hydrator\DelegatingHydratorFactory',
+        'zendstdlibhydratordelegatinghydrator'    => 'Zend\Stdlib\Hydrator\DelegatingHydratorFactory',
     ];
 }

--- a/test/Hydrator/HydratorPluginManagerTest.php
+++ b/test/Hydrator/HydratorPluginManagerTest.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zend-stdlib for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Stdlib\Hydrator;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use ReflectionProperty;
+use Zend\Hydrator\HydratorPluginManager as BasePluginManager;
+use Zend\Stdlib\Hydrator\HydratorInterface;
+use Zend\Stdlib\Hydrator\HydratorPluginManager;
+
+class HydratorPluginManagerTest extends TestCase
+{
+    public function setUp()
+    {
+        $this->hydrators = new HydratorPluginManager();
+    }
+
+    public function testExtendsZendHydratorPluginManager()
+    {
+        $this->assertInstanceOf(BasePluginManager::class, $this->hydrators);
+    }
+
+    public function aliases()
+    {
+        $hydrators = new HydratorPluginManager();
+        $r = new ReflectionProperty($hydrators, 'aliases');
+        $r->setAccessible(true);
+        foreach ($r->getValue($hydrators) as $alias => $target) {
+            yield $alias => [$alias, $target];
+        }
+    }
+
+    /**
+     * @dataProvider aliases
+     */
+    public function testAllAliasesReturnStdlibEquivalents($alias, $expected)
+    {
+        $this->assertContains('\\Stdlib\\', $expected, 'Alias target is not a Stdlib class?');
+
+        $hydrator = $this->hydrators->get($alias);
+        $this->assertInstanceOf(
+            $expected,
+            $hydrator,
+            sprintf('Alias %s did not retrieve expected %s instance; got %s', $alias, $expected, get_class($hydrator))
+        );
+        $this->assertInstanceOf(
+            HydratorInterface::class,
+            $hydrator,
+            sprintf('Alias %s resolved to %s, which is not a HydratorInterface instance', $alias, get_class($hydrator))
+        );
+    }
+
+    public function invokables()
+    {
+        $hydrators = new HydratorPluginManager();
+        $r = new ReflectionProperty($hydrators, 'invokableClasses');
+        $r->setAccessible(true);
+        foreach ($r->getValue($hydrators) as $name => $target) {
+            yield $name => [$name, $target];
+        }
+    }
+
+    /**
+     * @dataProvider invokables
+     */
+    public function testAllInvokablesReturnStdlibInstances($name, $expected)
+    {
+        $this->assertContains('\\Stdlib\\', $expected, 'Invokable target is not a Stdlib class?');
+
+        $hydrator = $this->hydrators->get($name);
+        $this->assertInstanceOf($expected, $hydrator, sprintf(
+            'Invokable %s did not retrieve expected %s instance; got %s',
+            $name,
+            $expected,
+            get_class($hydrator)
+        ));
+        $this->assertInstanceOf(HydratorInterface::class, $hydrator, sprintf(
+            'Invokable %s resolved to %s, which is not a HydratorInterface instance',
+            $name,
+            get_class($hydrator)
+        ));
+    }
+
+    public function factories()
+    {
+        $hydrators = new HydratorPluginManager();
+        $r = new ReflectionProperty($hydrators, 'factories');
+        $r->setAccessible(true);
+        foreach ($r->getValue($hydrators) as $name => $factory) {
+            yield $name => [$name, $factory];
+        }
+    }
+
+    /**
+     * @dataProvider factories
+     */
+    public function testAllFactoriesReturnStdlibInstances($name, $factory)
+    {
+        $hydrator = $this->hydrators->get($name);
+        $this->assertInstanceOf(HydratorInterface::class, $hydrator, sprintf(
+            'Factory for %s resolved to %s, which is not a HydratorInterface instance',
+            $name,
+            get_class($hydrator)
+        ));
+    }
+}


### PR DESCRIPTION
As noted in zendframework/zf2#7672, on updating to:

- zend-stdlib >= 2.7.0
- zend-mvc >= 2.6.0

backwards compatibility is broken with regards to typehints against hydrators. The reason is two-fold:

- The `HydratorPluginManager` is simply an extension of the one provided in zend-hydrator, meaning that all plugins returned are under the `Zend\Hydrator` namespace, not the `Zend\Stdlib\Hydrator` namespace.
- zend-mvc altered the `HydratorPluginManager` mapping to use the instance from zend-hydrator instead of zend-stdlib.

This patch addresses the first point of each. It does the following:

- Updates the DelegatingHydratorFactory to return a zend-stdlib instance.
- Updates the HydratorPluginManager to override the defaults from zend-hydrator, and have them return zend-stdlib extensions.
- Adds a test suite for HydratorPluginManager to verify backwards compatibility.

A related commit against the zend-mvc 2.6 series will occur shortly, having it use the zend-stdlib HydratorPluginManager.