### PR TITLE
Provide backwards compatibility for AggregateHydrator events

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     },
     "require": {
         "php": "^5.5 || ^7.0",
-        "zendframework/zend-hydrator": "~1.0"
+        "zendframework/zend-hydrator": "~1.1"
     },
     "require-dev": {
         "zendframework/zend-config": "~2.5",

--- a/src/Hydrator/Aggregate/AggregateHydrator.php
+++ b/src/Hydrator/Aggregate/AggregateHydrator.php
@@ -19,4 +19,27 @@ use Zend\Stdlib\Hydrator\HydratorInterface;
  */
 class AggregateHydrator extends BaseAggregateHydrator implements HydratorInterface
 {
+    /**
+     * {@inheritDoc}
+     */
+    public function extract($object)
+    {
+        $event = new ExtractEvent($this, $object);
+
+        $this->getEventManager()->triggerEvent($event);
+
+        return $event->getExtractedData();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function hydrate(array $data, $object)
+    {
+        $event = new HydrateEvent($this, $object, $data);
+
+        $this->getEventManager()->triggerEvent($event);
+
+        return $event->getHydratedObject();
+    }
 }

--- a/test/Hydrator/DelegatingHydratorFactoryTest.php
+++ b/test/Hydrator/DelegatingHydratorFactoryTest.php
@@ -9,17 +9,21 @@
 
 namespace ZendTest\Stdlib\Hydrator;
 
+use Interop\Container\ContainerInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
 use Zend\Stdlib\Hydrator\DelegatingHydratorFactory;
 
 class DelegatingHydratorFactoryTest extends \PHPUnit_Framework_TestCase
 {
     public function testFactory()
     {
-        $hydratorManager = $this->getMock('Zend\ServiceManager\ServiceLocatorInterface');
+        $hydratorManager = $this->prophesize(ServiceLocatorInterface::class);
+        $hydratorManager->willImplement(ContainerInterface::class);
+
         $factory = new DelegatingHydratorFactory();
         $this->assertInstanceOf(
             'Zend\Hydrator\DelegatingHydrator',
-            $factory->createService($hydratorManager)
+            $factory->createService($hydratorManager->reveal())
         );
     }
 }

--- a/test/Hydrator/DelegatingHydratorTest.php
+++ b/test/Hydrator/DelegatingHydratorTest.php
@@ -11,7 +11,6 @@ namespace ZendTest\Stdlib\Hydrator;
 
 use ArrayObject;
 use Interop\Container\ContainerInterface;
-use Prophecy\Argument;
 use Zend\ServiceManager\ServiceLocatorInterface;
 use Zend\Stdlib\Hydrator\DelegatingHydrator;
 use Zend\Stdlib\Hydrator\HydratorInterface;


### PR DESCRIPTION
Per #55 (and originally reported as zendframework/zend-hydrator#19), this patch does the following:

- Adds tests against the hydrate and extract methods to ensure that the event triggered is the zend-stdlib variant (as well as kept the tests for the zend-hydrator variants).
- Updated test expectations to check for `triggerEvent()` (and not `trigger()`), as the 1.1 version of zend-hydrator is now forwards-compatible with zend-eventmanager v3. This also required raising the minimum version of zend-hydrator to 1.1 so that tests do not need to be varied.
- Fixes the test assumptions in `testAdd()`, as attachment of the aggregate listener now calls the `attach()` method of the listener class, changing how the mock EM instance is called.
- Updates and fixes the `DelegatingHydrator(Factory)` tests, per similar changes done in zend-hydrator 1.1.