### PR TITLE
Check if GLOB_BRACE is defined before using it #58

### DIFF
--- a/src/Glob.php
+++ b/src/Glob.php
@@ -61,7 +61,7 @@ abstract class Glob
                 self::GLOB_NOSORT   => GLOB_NOSORT,
                 self::GLOB_NOCHECK  => GLOB_NOCHECK,
                 self::GLOB_NOESCAPE => GLOB_NOESCAPE,
-                self::GLOB_BRACE    => GLOB_BRACE,
+                self::GLOB_BRACE    => defined('GLOB_BRACE') ? GLOB_BRACE : 0,
                 self::GLOB_ONLYDIR  => GLOB_ONLYDIR,
                 self::GLOB_ERR      => GLOB_ERR,
             ];


### PR DESCRIPTION
This commit refers to the issue #58 and fixes an exception that was arising up on
systems based on MUSL (and probably other UNIX based rather than GNU Linux)

```
  [Exception]
  Notice: Use of undefined constant GLOB_BRACE - assumed 'GLOB_BRACE' in /magento/vendor/zendframework/zend-stdlib/src/Glob.php on line 64
```

closes #58