### PR TITLE
\Zend\Stdlib\FastPriorityQueue - an infinite loop and bugs in remove()

### DIFF
--- a/src/FastPriorityQueue.php
+++ b/src/FastPriorityQueue.php
@@ -57,9 +57,9 @@ class FastPriorityQueue implements Iterator, Countable, Serializable
     /**
      * Max priority
      *
-     * @var integer
+     * @var integer|null
      */
-    protected $maxPriority = 0;
+    protected $maxPriority = null;
 
     /**
      * Total number of elements in the queue
@@ -86,7 +86,7 @@ class FastPriorityQueue implements Iterator, Countable, Serializable
      * Insert an element in the queue with a specified priority
      *
      * @param mixed $value
-     * @param integer $priority a positive integer
+     * @param integer $priority
      */
     public function insert($value, $priority)
     {
@@ -96,7 +96,7 @@ class FastPriorityQueue implements Iterator, Countable, Serializable
         $this->values[$priority][] = $value;
         if (! isset($this->priorities[$priority])) {
             $this->priorities[$priority] = $priority;
-            $this->maxPriority           = max($priority, $this->maxPriority);
+            $this->maxPriority           = $this->maxPriority === null ? $priority : max($priority, $this->maxPriority);
         }
         ++$this->count;
     }
@@ -194,7 +194,7 @@ class FastPriorityQueue implements Iterator, Countable, Serializable
         if (false === next($this->values[$this->maxPriority])) {
             unset($this->priorities[$this->maxPriority]);
             unset($this->values[$this->maxPriority]);
-            $this->maxPriority = empty($this->priorities) ? 0 : max($this->priorities);
+            $this->maxPriority = empty($this->priorities) ? null : max($this->priorities);
             $this->subIndex    = -1;
         }
         ++$this->index;
@@ -211,7 +211,7 @@ class FastPriorityQueue implements Iterator, Countable, Serializable
         if (false === next($this->values[$this->maxPriority])) {
             unset($this->subPriorities[$this->maxPriority]);
             reset($this->values[$this->maxPriority]);
-            $this->maxPriority = empty($this->subPriorities) ? 0 : max($this->subPriorities);
+            $this->maxPriority = empty($this->subPriorities) ? null : max($this->subPriorities);
             $this->subIndex    = -1;
         }
         ++$this->index;

--- a/src/FastPriorityQueue.php
+++ b/src/FastPriorityQueue.php
@@ -150,7 +150,8 @@ class FastPriorityQueue implements Iterator, Countable, Serializable
                 $this->subIndex = $currentSubIndex;
 
                 // If the array is empty we need to destroy the unnecessary priority,
-                // otherwise we would end up with an incorrect value of `$this->count` {@see \Zend\Stdlib\FastPriorityQueue::nextAndRemove()}.
+                // otherwise we would end up with an incorrect value of `$this->count`
+                // {@see \Zend\Stdlib\FastPriorityQueue::nextAndRemove()}.
                 if (empty($this->values[$this->maxPriority])) {
                     unset($this->values[$this->maxPriority]);
                     unset($this->priorities[$this->maxPriority]);

--- a/src/FastPriorityQueue.php
+++ b/src/FastPriorityQueue.php
@@ -132,31 +132,31 @@ class FastPriorityQueue implements Iterator, Countable, Serializable
      */
     public function remove($datum)
     {
-    	$currentIndex    = $this->index;
-    	$currentSubIndex = $this->subIndex;
-    	$currentPriority = $this->maxPriority;
-    	
+        $currentIndex    = $this->index;
+        $currentSubIndex = $this->subIndex;
+        $currentPriority = $this->maxPriority;
+
         $this->rewind();
         while ($this->valid()) {
             if (current($this->values[$this->maxPriority]) === $datum) {
                 $index = key($this->values[$this->maxPriority]);
                 unset($this->values[$this->maxPriority][$index]);
-                
+
                 // The `next()` method advances the internal array pointer, so we need to use the `reset()` function,
                 // otherwise we would lose all elements before the place the pointer points.
                 reset($this->values[$this->maxPriority]);
-                
+
                 $this->index    = $currentIndex;
                 $this->subIndex = $currentSubIndex;
-                
+
                 // If the array is empty we need to destroy the unnecessary priority,
                 // otherwise we would end up with an incorrect value of `$this->count` {@see \Zend\Stdlib\FastPriorityQueue::nextAndRemove()}.
                 if (empty($this->values[$this->maxPriority])) {
-                	unset($this->values[$this->maxPriority]);
-                	unset($this->priorities[$this->maxPriority]);
-                	if ($this->maxPriority === $currentPriority) {
-                		$this->subIndex = 0;
-                	}
+                    unset($this->values[$this->maxPriority]);
+                    unset($this->priorities[$this->maxPriority]);
+                    if ($this->maxPriority === $currentPriority) {
+                        $this->subIndex = 0;
+                    }
                 }
 
                 $this->maxPriority = empty($this->priorities) ? null : max($this->priorities);
@@ -214,15 +214,15 @@ class FastPriorityQueue implements Iterator, Countable, Serializable
      */
     protected function nextAndRemove()
     {
-    	$key = key($this->values[$this->maxPriority]);
-    	
+        $key = key($this->values[$this->maxPriority]);
+
         if (false === next($this->values[$this->maxPriority])) {
             unset($this->priorities[$this->maxPriority]);
             unset($this->values[$this->maxPriority]);
             $this->maxPriority = empty($this->priorities) ? null : max($this->priorities);
             $this->subIndex    = -1;
         } else {
-        	unset($this->values[$this->maxPriority][$key]);
+            unset($this->values[$this->maxPriority][$key]);
         }
         ++$this->index;
         ++$this->subIndex;

--- a/src/FastPriorityQueue.php
+++ b/src/FastPriorityQueue.php
@@ -132,11 +132,34 @@ class FastPriorityQueue implements Iterator, Countable, Serializable
      */
     public function remove($datum)
     {
+    	$currentIndex    = $this->index;
+    	$currentSubIndex = $this->subIndex;
+    	$currentPriority = $this->maxPriority;
+    	
         $this->rewind();
         while ($this->valid()) {
             if (current($this->values[$this->maxPriority]) === $datum) {
                 $index = key($this->values[$this->maxPriority]);
                 unset($this->values[$this->maxPriority][$index]);
+                
+                // The `next()` method advances the internal array pointer, so we need to use the `reset()` function,
+                // otherwise we would lose all elements before the place the pointer points.
+                reset($this->values[$this->maxPriority]);
+                
+                $this->index    = $currentIndex;
+                $this->subIndex = $currentSubIndex;
+                
+                // If the array is empty we need to destroy the unnecessary priority,
+                // otherwise we would end up with an incorrect value of `$this->count` {@see \Zend\Stdlib\FastPriorityQueue::nextAndRemove()}.
+                if (empty($this->values[$this->maxPriority])) {
+                	unset($this->values[$this->maxPriority]);
+                	unset($this->priorities[$this->maxPriority]);
+                	if ($this->maxPriority === $currentPriority) {
+                		$this->subIndex = 0;
+                	}
+                }
+
+                $this->maxPriority = empty($this->priorities) ? null : max($this->priorities);
                 --$this->count;
                 return true;
             }
@@ -191,11 +214,15 @@ class FastPriorityQueue implements Iterator, Countable, Serializable
      */
     protected function nextAndRemove()
     {
+    	$key = key($this->values[$this->maxPriority]);
+    	
         if (false === next($this->values[$this->maxPriority])) {
             unset($this->priorities[$this->maxPriority]);
             unset($this->values[$this->maxPriority]);
             $this->maxPriority = empty($this->priorities) ? null : max($this->priorities);
             $this->subIndex    = -1;
+        } else {
+        	unset($this->values[$this->maxPriority][$key]);
         }
         ++$this->index;
         ++$this->subIndex;

--- a/test/FastPriorityQueueTest.php
+++ b/test/FastPriorityQueueTest.php
@@ -285,4 +285,59 @@ class FastPriorityQueueTest extends \PHPUnit_Framework_TestCase
             $this->assertFalse($queue->contains($listener), sprintf('Listener %s remained in queue', $i));
         }
     }
+
+    public function testRemoveShouldNotAffectExtract()
+    {
+        // Removing an element with low priority
+        $queue = new FastPriorityQueue();
+        $queue->insert('a1', 1);
+        $queue->insert('a2', 1);
+        $queue->insert('b', 2);
+        $equals->remove('a1');
+        $expected = ['b', 'a2'];
+        $test = [];
+        while ($value = $queue->extract()) {
+            $test[] = $value;
+        }
+        $this->assertEquals($expected, $test);
+        $this->assertTrue($queue->isEmpty());
+
+        // Removing an element in the middle of a set of elements with the same priority
+        $queue->insert('a1', 1);
+        $queue->insert('a2', 1);
+        $queue->insert('a3', 1);
+        $equals->remove('a2');
+        $expected = ['a1', 'a3'];
+        $test = [];
+        while ($value = $queue->extract()) {
+            $test[] = $value;
+        }
+        $this->assertEquals($expected, $test);
+        $this->assertTrue($queue->isEmpty());
+
+        // Removing an element with high priority
+        $queue->insert('a', 1);
+        $queue->insert('b', 2);
+        $equals->remove('b');
+        $expected = ['a'];
+        $test = [];
+        while ($value = $queue->extract()) {
+            $test[] = $value;
+        }
+        $this->assertEquals($expected, $test);
+        $this->assertTrue($queue->isEmpty());
+    }
+
+    public testZeroPriority()
+    {
+        $queue = new FastPriorityQueue();
+        $queue->insert('a', 0);
+        $queue->insert('b', 1);
+        $expected = ['b', 'a'];
+        $test = [];
+        foreach ($queue as $value) {
+            $test[] = $value;
+        }
+        $this->assertEquals($expected, $test);
+    }
 }

--- a/test/FastPriorityQueueTest.php
+++ b/test/FastPriorityQueueTest.php
@@ -328,7 +328,7 @@ class FastPriorityQueueTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($queue->isEmpty());
     }
 
-    public testZeroPriority()
+    public function testZeroPriority()
     {
         $queue = new FastPriorityQueue();
         $queue->insert('a', 0);

--- a/test/FastPriorityQueueTest.php
+++ b/test/FastPriorityQueueTest.php
@@ -293,7 +293,7 @@ class FastPriorityQueueTest extends \PHPUnit_Framework_TestCase
         $queue->insert('a1', 1);
         $queue->insert('a2', 1);
         $queue->insert('b', 2);
-        $equals->remove('a1');
+        $queue->remove('a1');
         $expected = ['b', 'a2'];
         $test = [];
         while ($value = $queue->extract()) {
@@ -306,7 +306,7 @@ class FastPriorityQueueTest extends \PHPUnit_Framework_TestCase
         $queue->insert('a1', 1);
         $queue->insert('a2', 1);
         $queue->insert('a3', 1);
-        $equals->remove('a2');
+        $queue->remove('a2');
         $expected = ['a1', 'a3'];
         $test = [];
         while ($value = $queue->extract()) {
@@ -318,7 +318,7 @@ class FastPriorityQueueTest extends \PHPUnit_Framework_TestCase
         // Removing an element with high priority
         $queue->insert('a', 1);
         $queue->insert('b', 2);
-        $equals->remove('b');
+        $queue->remove('b');
         $expected = ['a'];
         $test = [];
         while ($value = $queue->extract()) {


### PR DESCRIPTION
I see a few problems in the class.
- An infinite loop:

``` php
$queue = new FastPriorityQueue();
$queue->insert('a', 0);
$queue->insert('b', 1);
foreach ($queue as $value) {echo $value;} // here we fall into an infinite loop
```

Other problems are concerned with the implementation of the `remove()` method.
- `remove()` changes a value of `this->maxPriority`:

``` php
$queue = new FastPriorityQueue();
$queue->insert('a1', 1);
$queue->insert('a2', 1);
$queue->insert('b2', 2);
$queue->remove('a1');
echo $queue->extract(); // it prints 'a2' but should 'b2'
```
- `remove()` uses the `next()` method thus it changes the internal array pointer:

``` php
$queue = new FastPriorityQueue();
$queue->insert('a1', 1);
$queue->insert('a2', 1);
$queue->insert('a3', 1);
$queue->remove('a2');
echo $queue->extract(); // it prints 'a3' but should 'a1', 'a1' is lost
```
- `remove()` doesn't destroy the unnecessary priority from the array of priorities which implies the following behaviour:

``` php
$queue = new FastPriorityQueue();
$queue->insert('a', 1);
$queue->insert('b', 2);
$queue->remove('b');
echo $queue->extract(); // it prints an empty string but should 'a'
echo $queue->count();   // it prints 0, but there is still one element in the queue
echo $queue->extract(); // it prints 'a' which should happen when the `extract()` method was called the first time
```

This PR fixes all these issues.
