### PR TITLE
QA tool updates and PHP 5.5 removal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,15 +24,14 @@ env:
 matrix:
   fast_finish: true
   include:
-    - php: 5.5
-      env:
-        - EXECUTE_CS_CHECK=true
     - php: 5.6
       env:
-        - EXECUTE_TEST_COVERALLS=true
+        - TEST_COVERAGE=true
         - DEPLOY_DOCS="$(if [[ $TRAVIS_BRANCH == 'master' && $TRAVIS_PULL_REQUEST == 'false' ]]; then echo -n 'true' ; else echo -n 'false' ; fi)"
         - PATH="$HOME/.local/bin:$PATH"
     - php: 7
+      env:
+        - CS_CHECK=true
     - php: hhvm 
   allow_failures:
     - php: hhvm
@@ -42,21 +41,21 @@ notifications:
   email: false
 
 before_install:
-  - if [[ $EXECUTE_TEST_COVERALLS != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi
+  - if [[ $TEST_COVERAGE != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi
   - composer self-update
-  - if [[ $EXECUTE_TEST_COVERALLS == 'true' ]]; then composer require --dev --no-update satooshi/php-coveralls ; fi
+  - if [[ $TEST_COVERAGE == 'true' ]]; then composer require --dev --no-update satooshi/php-coveralls ; fi
 
 install:
   - travis_retry composer install --no-interaction --ignore-platform-reqs
 
 script:
-  - if [[ $EXECUTE_TEST_COVERALLS == 'true' ]]; then ./vendor/bin/phpunit --coverage-clover clover.xml ; fi
-  - if [[ $EXECUTE_TEST_COVERALLS != 'true' ]]; then ./vendor/bin/phpunit ; fi
-  - if [[ $EXECUTE_CS_CHECK == 'true' ]]; then ./vendor/bin/php-cs-fixer fix -v --diff --dry-run ; fi
+  - if [[ $TEST_COVERAGE == 'true' ]]; then composer test-coverage ; fi
+  - if [[ $TEST_COVERAGE != 'true' ]]; then composer test ; fi
+  - if [[ $CS_CHECK == 'true' ]]; then composer cs-check ; fi
   - if [[ $DEPLOY_DOCS == "true" && "$TRAVIS_TEST_RESULT" == "0" ]]; then wget -O theme-installer.sh "https://raw.githubusercontent.com/zendframework/zf-mkdoc-theme/master/theme-installer.sh" ; chmod 755 theme-installer.sh ; ./theme-installer.sh ; fi
 
 after_success:
   - if [[ $DEPLOY_DOCS == "true" ]]; then echo "Preparing to build and deploy documentation" ; ./zf-mkdoc-theme/deploy.sh ; echo "Completed deploying documentation" ; fi
 
 after_script:
-  - if [[ $EXECUTE_TEST_COVERALLS == 'true' ]]; then ./vendor/bin/coveralls ; fi
+  - if [[ $TEST_COVERAGE == 'true' ]]; then composer upload-coverage ; fi

--- a/composer.json
+++ b/composer.json
@@ -13,12 +13,12 @@
         }
     },
     "require": {
-        "php": "^5.5 || ^7.0"
+        "php": "^5.6 || ^7.0"
     },
     "require-dev": {
-        "fabpot/php-cs-fixer": "1.7.*",
+        "athletic/athletic": "~0.1",
         "phpunit/PHPUnit": "~4.0",
-        "athletic/athletic": "~0.1"
+        "squizlabs/php_codesniffer": "^2.6.2"
     },
     "extra": {
         "branch-alias": {
@@ -31,5 +31,12 @@
             "ZendTest\\Stdlib\\": "test/",
             "ZendBench\\Stdlib\\": "benchmark/"
         }
+    },
+    "scripts": {
+        "cs-check": "phpcs --colors",
+        "cs-fix": "phpcbf --colors",
+        "test": "phpunit --colors=always",
+        "test-coverage": "phpunit --colors=always --coverage-clover clover.xml",
+        "upload-coverage": "coveralls -v"
     }
 }

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<ruleset name="Zend Framework coding standard">
+    <description>Zend Framework coding standard</description>
+
+    <!-- display progress -->
+    <arg value="p"/>
+    <arg name="colors"/>
+
+    <!-- inherit rules from: -->
+    <rule ref="PSR2"/>
+    <rule ref="Generic.Arrays.DisallowLongArraySyntax"/>
+    <rule ref="Generic.Formatting.SpaceAfterNot"/>
+    <rule ref="Squiz.WhiteSpace.OperatorSpacing">
+        <properties>
+            <property name="ignoreNewlines" value="true"/>
+        </properties>
+    </rule>
+    <rule ref="Squiz.WhiteSpace.SuperfluousWhitespace">
+        <properties>
+            <property name="ignoreBlankLines" value="false"/>
+        </properties>
+    </rule>
+
+    <!-- Paths to check -->
+    <file>src</file>
+    <file>test</file>
+</ruleset>

--- a/src/AbstractOptions.php
+++ b/src/AbstractOptions.php
@@ -13,6 +13,7 @@ use Traversable;
 
 abstract class AbstractOptions implements ParameterObjectInterface
 {
+    // @codingStandardsIgnoreStart
     /**
      * We use the __ prefix to avoid collisions with properties in
      * user-implementations.
@@ -20,6 +21,7 @@ abstract class AbstractOptions implements ParameterObjectInterface
      * @var bool
      */
     protected $__strictMode__ = true;
+    // @codingStandardsIgnoreEnd
 
     /**
      * Constructor
@@ -46,7 +48,7 @@ abstract class AbstractOptions implements ParameterObjectInterface
             $options = $options->toArray();
         }
 
-        if (!is_array($options) && !$options instanceof Traversable) {
+        if (! is_array($options) && ! $options instanceof Traversable) {
             throw new Exception\InvalidArgumentException(
                 sprintf(
                     'Parameter provided to %s must be an %s, %s or %s',

--- a/src/ArrayObject.php
+++ b/src/ArrayObject.php
@@ -180,14 +180,16 @@ class ArrayObject implements IteratorAggregate, ArrayAccess, Serializable, Count
      */
     public function exchangeArray($data)
     {
-        if (!is_array($data) && !is_object($data)) {
-            throw new Exception\InvalidArgumentException('Passed variable is not an array or object, using empty array instead');
+        if (! is_array($data) && ! is_object($data)) {
+            throw new Exception\InvalidArgumentException(
+                'Passed variable is not an array or object, using empty array instead'
+            );
         }
 
         if (is_object($data) && ($data instanceof self || $data instanceof \ArrayObject)) {
             $data = $data->getArrayCopy();
         }
-        if (!is_array($data)) {
+        if (! is_array($data)) {
             $data = (array) $data;
         }
 
@@ -290,7 +292,7 @@ class ArrayObject implements IteratorAggregate, ArrayAccess, Serializable, Count
     public function &offsetGet($key)
     {
         $ret = null;
-        if (!$this->offsetExists($key)) {
+        if (! $this->offsetExists($key)) {
             return $ret;
         }
         $ret =& $this->storage[$key];

--- a/src/ArrayUtils.php
+++ b/src/ArrayUtils.php
@@ -39,11 +39,11 @@ abstract class ArrayUtils
      */
     public static function hasStringKeys($value, $allowEmpty = false)
     {
-        if (!is_array($value)) {
+        if (! is_array($value)) {
             return false;
         }
 
-        if (!$value) {
+        if (! $value) {
             return $allowEmpty;
         }
 
@@ -59,11 +59,11 @@ abstract class ArrayUtils
      */
     public static function hasIntegerKeys($value, $allowEmpty = false)
     {
-        if (!is_array($value)) {
+        if (! is_array($value)) {
             return false;
         }
 
-        if (!$value) {
+        if (! $value) {
             return $allowEmpty;
         }
 
@@ -86,11 +86,11 @@ abstract class ArrayUtils
      */
     public static function hasNumericKeys($value, $allowEmpty = false)
     {
-        if (!is_array($value)) {
+        if (! is_array($value)) {
             return false;
         }
 
-        if (!$value) {
+        if (! $value) {
             return $allowEmpty;
         }
 
@@ -119,11 +119,11 @@ abstract class ArrayUtils
      */
     public static function isList($value, $allowEmpty = false)
     {
-        if (!is_array($value)) {
+        if (! is_array($value)) {
             return false;
         }
 
-        if (!$value) {
+        if (! $value) {
             return $allowEmpty;
         }
 
@@ -161,11 +161,11 @@ abstract class ArrayUtils
      */
     public static function isHashTable($value, $allowEmpty = false)
     {
-        if (!is_array($value)) {
+        if (! is_array($value)) {
             return false;
         }
 
-        if (!$value) {
+        if (! $value) {
             return $allowEmpty;
         }
 
@@ -187,7 +187,7 @@ abstract class ArrayUtils
      */
     public static function inArray($needle, array $haystack, $strict = false)
     {
-        if (!$strict) {
+        if (! $strict) {
             if (is_int($needle) || is_float($needle)) {
                 $needle = (string) $needle;
             }
@@ -215,11 +215,11 @@ abstract class ArrayUtils
      */
     public static function iteratorToArray($iterator, $recursive = true)
     {
-        if (!is_array($iterator) && !$iterator instanceof Traversable) {
+        if (! is_array($iterator) && ! $iterator instanceof Traversable) {
             throw new Exception\InvalidArgumentException(__METHOD__ . ' expects an array or Traversable object');
         }
 
-        if (!$recursive) {
+        if (! $recursive) {
             if (is_array($iterator)) {
                 return $iterator;
             }
@@ -274,7 +274,7 @@ abstract class ArrayUtils
             } elseif (isset($a[$key]) || array_key_exists($key, $a)) {
                 if ($value instanceof MergeRemoveKey) {
                     unset($a[$key]);
-                } elseif (!$preserveNumericKeys && is_int($key)) {
+                } elseif (! $preserveNumericKeys && is_int($key)) {
                     $a[] = $value;
                 } elseif (is_array($value) && is_array($a[$key])) {
                     $a[$key] = static::merge($a[$key], $value, $preserveNumericKeys);
@@ -282,7 +282,7 @@ abstract class ArrayUtils
                     $a[$key] = $value;
                 }
             } else {
-                if (!$value instanceof MergeRemoveKey) {
+                if (! $value instanceof MergeRemoveKey) {
                     $a[$key] = $value;
                 }
             }

--- a/src/ErrorHandler.php
+++ b/src/ErrorHandler.php
@@ -51,7 +51,7 @@ abstract class ErrorHandler
      */
     public static function start($errorLevel = \E_WARNING)
     {
-        if (!static::$stack) {
+        if (! static::$stack) {
             set_error_handler([get_called_class(), 'addError'], $errorLevel);
         }
 
@@ -72,7 +72,7 @@ abstract class ErrorHandler
         if (static::$stack) {
             $errorException = array_pop(static::$stack);
 
-            if (!static::$stack) {
+            if (! static::$stack) {
                 restore_error_handler();
             }
 

--- a/src/Glob.php
+++ b/src/Glob.php
@@ -38,7 +38,7 @@ abstract class Glob
      */
     public static function glob($pattern, $flags = 0, $forceFallback = false)
     {
-        if (!defined('GLOB_BRACE') || $forceFallback) {
+        if (! defined('GLOB_BRACE') || $forceFallback) {
             return static::fallbackGlob($pattern, $flags);
         }
 
@@ -96,7 +96,7 @@ abstract class Glob
      */
     protected static function fallbackGlob($pattern, $flags)
     {
-        if (!$flags & self::GLOB_BRACE) {
+        if (! $flags & self::GLOB_BRACE) {
             return static::systemGlob($pattern, $flags);
         }
 
@@ -182,7 +182,7 @@ abstract class Glob
         $current = $begin;
 
         while ($current < $length) {
-            if (!$flags & self::GLOB_NOESCAPE && $pattern[$current] === '\\') {
+            if (! $flags & self::GLOB_NOESCAPE && $pattern[$current] === '\\') {
                 if (++$current === $length) {
                     break;
                 }

--- a/src/Guard/ArrayOrTraversableGuardTrait.php
+++ b/src/Guard/ArrayOrTraversableGuardTrait.php
@@ -29,7 +29,7 @@ trait ArrayOrTraversableGuardTrait
         $dataName = 'Argument',
         $exceptionClass = 'Zend\Stdlib\Exception\InvalidArgumentException'
     ) {
-        if (!is_array($data) && !($data instanceof Traversable)) {
+        if (! is_array($data) && ! ($data instanceof Traversable)) {
             $message = sprintf(
                 "%s must be an array or Traversable, [%s] given",
                 $dataName,

--- a/src/Message.php
+++ b/src/Message.php
@@ -40,7 +40,7 @@ class Message implements MessageInterface
             $this->metadata[$spec] = $value;
             return $this;
         }
-        if (!is_array($spec) && !$spec instanceof Traversable) {
+        if (! is_array($spec) && ! $spec instanceof Traversable) {
             throw new Exception\InvalidArgumentException(sprintf(
                 'Expected a string, array, or Traversable argument in first position; received "%s"',
                 (is_object($spec) ? get_class($spec) : gettype($spec))
@@ -66,7 +66,7 @@ class Message implements MessageInterface
             return $this->metadata;
         }
 
-        if (!is_scalar($key)) {
+        if (! is_scalar($key)) {
             throw new Exception\InvalidArgumentException('Non-scalar argument provided for key');
         }
 

--- a/src/PriorityList.php
+++ b/src/PriorityList.php
@@ -62,7 +62,7 @@ class PriorityList implements Iterator, Countable
      */
     public function insert($name, $value, $priority = 0)
     {
-        if (!isset($this->items[$name])) {
+        if (! isset($this->items[$name])) {
             $this->count++;
         }
 
@@ -85,7 +85,7 @@ class PriorityList implements Iterator, Countable
      */
     public function setPriority($name, $priority)
     {
-        if (!isset($this->items[$name])) {
+        if (! isset($this->items[$name])) {
             throw new \Exception("item $name not found");
         }
 
@@ -131,7 +131,7 @@ class PriorityList implements Iterator, Countable
      */
     public function get($name)
     {
-        if (!isset($this->items[$name])) {
+        if (! isset($this->items[$name])) {
             return;
         }
 
@@ -145,7 +145,7 @@ class PriorityList implements Iterator, Countable
      */
     protected function sort()
     {
-        if (!$this->sorted) {
+        if (! $this->sorted) {
             uasort($this->items, [$this, 'compare']);
             $this->sorted = true;
         }
@@ -161,7 +161,7 @@ class PriorityList implements Iterator, Countable
     protected function compare(array $item1, array $item2)
     {
         return ($item1['priority'] === $item2['priority'])
-            ? ($item1['serial']   > $item2['serial']   ? -1 : 1) * $this->isLIFO
+            ? ($item1['serial'] > $item2['serial'] ? -1 : 1) * $this->isLIFO
             : ($item1['priority'] > $item2['priority'] ? -1 : 1);
     }
 

--- a/src/PriorityQueue.php
+++ b/src/PriorityQueue.php
@@ -99,7 +99,7 @@ class PriorityQueue implements Countable, IteratorAggregate, Serializable
             unset($this->items[$key]);
             $this->queue = null;
 
-            if (!$this->isEmpty()) {
+            if (! $this->isEmpty()) {
                 $queue = $this->getQueue();
                 foreach ($this->items as $item) {
                     $queue->insert($item['data'], $item['priority']);
@@ -277,7 +277,7 @@ class PriorityQueue implements Countable, IteratorAggregate, Serializable
     {
         if (null === $this->queue) {
             $this->queue = new $this->queueClass();
-            if (!$this->queue instanceof \SplPriorityQueue) {
+            if (! $this->queue instanceof \SplPriorityQueue) {
                 throw new Exception\DomainException(sprintf(
                     'PriorityQueue expects an internal queue of type SplPriorityQueue; received "%s"',
                     get_class($this->queue)

--- a/src/SplPriorityQueue.php
+++ b/src/SplPriorityQueue.php
@@ -36,7 +36,7 @@ class SplPriorityQueue extends \SplPriorityQueue implements Serializable
      */
     public function insert($datum, $priority)
     {
-        if (!is_array($priority)) {
+        if (! is_array($priority)) {
             $priority = [$priority, $this->serial--];
         }
         parent::insert($datum, $priority);

--- a/src/StringUtils.php
+++ b/src/StringUtils.php
@@ -84,7 +84,7 @@ abstract class StringUtils
     public static function registerWrapper($wrapper)
     {
         $wrapper = (string) $wrapper;
-        if (!in_array($wrapper, static::$wrapperRegistry, true)) {
+        if (! in_array($wrapper, static::$wrapperRegistry, true)) {
             static::$wrapperRegistry[] = $wrapper;
         }
     }

--- a/src/StringWrapper/AbstractStringWrapper.php
+++ b/src/StringWrapper/AbstractStringWrapper.php
@@ -38,11 +38,11 @@ abstract class AbstractStringWrapper implements StringWrapperInterface
     {
         $supportedEncodings = static::getSupportedEncodings();
 
-        if (!in_array(strtoupper($encoding), $supportedEncodings)) {
+        if (! in_array(strtoupper($encoding), $supportedEncodings)) {
             return false;
         }
 
-        if ($convertEncoding !== null && !in_array(strtoupper($convertEncoding), $supportedEncodings)) {
+        if ($convertEncoding !== null && ! in_array(strtoupper($convertEncoding), $supportedEncodings)) {
             return false;
         }
 
@@ -61,7 +61,7 @@ abstract class AbstractStringWrapper implements StringWrapperInterface
         $supportedEncodings = static::getSupportedEncodings();
 
         $encodingUpper = strtoupper($encoding);
-        if (!in_array($encodingUpper, $supportedEncodings)) {
+        if (! in_array($encodingUpper, $supportedEncodings)) {
             throw new Exception\InvalidArgumentException(
                 'Wrapper doesn\'t support character encoding "' . $encoding . '"'
             );
@@ -69,7 +69,7 @@ abstract class AbstractStringWrapper implements StringWrapperInterface
 
         if ($convertEncoding !== null) {
             $convertEncodingUpper = strtoupper($convertEncoding);
-            if (!in_array($convertEncodingUpper, $supportedEncodings)) {
+            if (! in_array($convertEncodingUpper, $supportedEncodings)) {
                 throw new Exception\InvalidArgumentException(
                     'Wrapper doesn\'t support character encoding "' . $convertEncoding . '"'
                 );

--- a/src/StringWrapper/Iconv.php
+++ b/src/StringWrapper/Iconv.php
@@ -214,7 +214,7 @@ class Iconv extends AbstractStringWrapper
      */
     public function __construct()
     {
-        if (!extension_loaded('iconv')) {
+        if (! extension_loaded('iconv')) {
             throw new Exception\ExtensionNotLoadedException(
                 'PHP extension "iconv" is required for this wrapper'
             );

--- a/src/StringWrapper/Intl.php
+++ b/src/StringWrapper/Intl.php
@@ -37,7 +37,7 @@ class Intl extends AbstractStringWrapper
      */
     public function __construct()
     {
-        if (!extension_loaded('intl')) {
+        if (! extension_loaded('intl')) {
             throw new Exception\ExtensionNotLoadedException(
                 'PHP extension "intl" is required for this wrapper'
             );

--- a/src/StringWrapper/MbString.php
+++ b/src/StringWrapper/MbString.php
@@ -48,7 +48,7 @@ class MbString extends AbstractStringWrapper
      */
     public function __construct()
     {
-        if (!extension_loaded('mbstring')) {
+        if (! extension_loaded('mbstring')) {
             throw new Exception\ExtensionNotLoadedException(
                 'PHP extension "mbstring" is required for this wrapper'
             );

--- a/src/StringWrapper/Native.php
+++ b/src/StringWrapper/Native.php
@@ -35,7 +35,7 @@ class Native extends AbstractStringWrapper
         $encodingUpper      = strtoupper($encoding);
         $supportedEncodings = static::getSupportedEncodings();
 
-        if (!in_array($encodingUpper, $supportedEncodings)) {
+        if (! in_array($encodingUpper, $supportedEncodings)) {
             return false;
         }
 
@@ -69,7 +69,7 @@ class Native extends AbstractStringWrapper
         $supportedEncodings = static::getSupportedEncodings();
 
         $encodingUpper = strtoupper($encoding);
-        if (!in_array($encodingUpper, $supportedEncodings)) {
+        if (! in_array($encodingUpper, $supportedEncodings)) {
             throw new Exception\InvalidArgumentException(
                 'Wrapper doesn\'t support character encoding "' . $encoding . '"'
             );

--- a/test/FastPriorityQueueTest.php
+++ b/test/FastPriorityQueueTest.php
@@ -107,7 +107,11 @@ class FastPriorityQueueTest extends \PHPUnit_Framework_TestCase
         $s = serialize($this->queue);
         $unserialized = unserialize($s);
         $count = count($this->queue);
-        $this->assertSame($count, count($unserialized), 'Expected count ' . $count . '; received ' . count($unserialized));
+        $this->assertSame(
+            $count,
+            count($unserialized),
+            'Expected count ' . $count . '; received ' . count($unserialized)
+        );
 
         $expected = [];
         foreach ($this->queue as $item) {
@@ -117,7 +121,11 @@ class FastPriorityQueueTest extends \PHPUnit_Framework_TestCase
         foreach ($unserialized as $item) {
             $test[] = $item;
         }
-        $this->assertSame($expected, $test, 'Expected: ' . var_export($expected, 1) . "\nReceived:" . var_export($test, 1));
+        $this->assertSame(
+            $expected,
+            $test,
+            'Expected: ' . var_export($expected, 1) . "\nReceived:" . var_export($test, 1)
+        );
     }
 
     public function testCanRetrieveQueueAsArray()

--- a/test/GlobTest.php
+++ b/test/GlobTest.php
@@ -16,7 +16,7 @@ class GlobTest extends TestCase
 {
     public function testFallback()
     {
-        if (!defined('GLOB_BRACE')) {
+        if (! defined('GLOB_BRACE')) {
             $this->markTestSkipped('GLOB_BRACE not available');
         }
 

--- a/test/PriorityListTest.php
+++ b/test/PriorityListTest.php
@@ -95,9 +95,9 @@ class PriorityListTest extends TestCase
 
     public function testLIFOOnly()
     {
-        $this->list->insert('foo',    new \stdClass());
-        $this->list->insert('bar',    new \stdClass());
-        $this->list->insert('baz',    new \stdClass());
+        $this->list->insert('foo', new \stdClass());
+        $this->list->insert('bar', new \stdClass());
+        $this->list->insert('baz', new \stdClass());
         $this->list->insert('foobar', new \stdClass());
         $this->list->insert('barbaz', new \stdClass());
 
@@ -143,9 +143,9 @@ class PriorityListTest extends TestCase
     public function testFIFOOnly()
     {
         $this->list->isLIFO(false);
-        $this->list->insert('foo',    new \stdClass());
-        $this->list->insert('bar',    new \stdClass());
-        $this->list->insert('baz',    new \stdClass());
+        $this->list->insert('foo', new \stdClass());
+        $this->list->insert('bar', new \stdClass());
+        $this->list->insert('baz', new \stdClass());
         $this->list->insert('foobar', new \stdClass());
         $this->list->insert('barbaz', new \stdClass());
 
@@ -202,8 +202,8 @@ class PriorityListTest extends TestCase
 
         $this->assertEquals(
             [
-                'bar' => ['data' => 'bar_value', 'priority' =>  1, 'serial' => 1],
-                'foo' => ['data' => 'foo_value', 'priority' =>  0, 'serial' => 0],
+                'bar' => ['data' => 'bar_value', 'priority' => 1, 'serial' => 1],
+                'foo' => ['data' => 'foo_value', 'priority' => 0, 'serial' => 0],
                 'baz' => ['data' => 'baz_value', 'priority' => -1, 'serial' => 2],
             ],
             $this->list->toArray(PriorityList::EXTR_BOTH)

--- a/test/PriorityQueueTest.php
+++ b/test/PriorityQueueTest.php
@@ -35,11 +35,19 @@ class PriorityQueueTest extends \PHPUnit_Framework_TestCase
         $s = serialize($this->queue);
         $unserialized = unserialize($s);
         $count = count($this->queue);
-        $this->assertSame($count, count($unserialized), 'Expected count ' . $count . '; received ' . count($unserialized));
+        $this->assertSame(
+            $count,
+            count($unserialized),
+            'Expected count ' . $count . '; received ' . count($unserialized)
+        );
 
         $expected = iterator_to_array($this->queue);
         $test = iterator_to_array($unserialized);
-        $this->assertSame($expected, $test, 'Expected: ' . var_export($expected, 1) . "\nReceived:" . var_export($test, 1));
+        $this->assertSame(
+            $expected,
+            $test,
+            'Expected: ' . var_export($expected, 1) . "\nReceived:" . var_export($test, 1)
+        );
     }
 
     public function testRetrievingQueueAsArrayReturnsDataOnlyByDefault()
@@ -122,7 +130,7 @@ class PriorityQueueTest extends \PHPUnit_Framework_TestCase
 
         $queueClone = clone $queue;
 
-        while (!$queue->isEmpty()) {
+        while (! $queue->isEmpty()) {
             $this->assertSame($foo, $queue->top());
             $queue->remove($queue->top());
         }
@@ -131,7 +139,7 @@ class PriorityQueueTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($queueClone->isEmpty());
         $this->assertEquals(2, $queueClone->count());
 
-        while (!$queueClone->isEmpty()) {
+        while (! $queueClone->isEmpty()) {
             $this->assertSame($foo, $queueClone->top());
             $queueClone->remove($queueClone->top());
         }

--- a/test/SplPriorityQueueTest.php
+++ b/test/SplPriorityQueueTest.php
@@ -48,11 +48,19 @@ class SplPriorityQueueTest extends \PHPUnit_Framework_TestCase
         $s = serialize($this->queue);
         $unserialized = unserialize($s);
         $count = count($this->queue);
-        $this->assertSame($count, count($unserialized), 'Expected count ' . $count . '; received ' . count($unserialized));
+        $this->assertSame(
+            $count,
+            count($unserialized),
+            'Expected count ' . $count . '; received ' . count($unserialized)
+        );
 
         $expected = iterator_to_array($this->queue);
         $test = iterator_to_array($unserialized);
-        $this->assertSame($expected, $test, 'Expected: ' . var_export($expected, 1) . "\nReceived:" . var_export($test, 1));
+        $this->assertSame(
+            $expected,
+            $test,
+            'Expected: ' . var_export($expected, 1) . "\nReceived:" . var_export($test, 1)
+        );
     }
 
     public function testCanRetrieveQueueAsArray()

--- a/test/StringWrapper/CommonStringWrapperTest.php
+++ b/test/StringWrapper/CommonStringWrapperTest.php
@@ -37,7 +37,7 @@ abstract class CommonStringWrapperTest extends TestCase
     public function testStrlen($encoding, $str, $expected)
     {
         $wrapper = $this->getWrapper($encoding);
-        if (!$wrapper) {
+        if (! $wrapper) {
             $this->markTestSkipped("Encoding {$encoding} not supported");
         }
 
@@ -65,7 +65,7 @@ abstract class CommonStringWrapperTest extends TestCase
     public function testSubstr($encoding, $str, $offset, $length, $expected)
     {
         $wrapper = $this->getWrapper($encoding);
-        if (!$wrapper) {
+        if (! $wrapper) {
             $this->markTestSkipped("Encoding {$encoding} not supported");
         }
 
@@ -93,7 +93,7 @@ abstract class CommonStringWrapperTest extends TestCase
     public function testStrpos($encoding, $haystack, $needle, $offset, $expected)
     {
         $wrapper = $this->getWrapper($encoding);
-        if (!$wrapper) {
+        if (! $wrapper) {
             $this->markTestSkipped("Encoding {$encoding} not supported");
         }
 
@@ -122,7 +122,7 @@ abstract class CommonStringWrapperTest extends TestCase
     public function testConvert($encoding, $convertEncoding, $str, $expected)
     {
         $wrapper = $this->getWrapper($encoding, $convertEncoding);
-        if (!$wrapper) {
+        if (! $wrapper) {
             $this->markTestSkipped("Encoding {$encoding} or {$convertEncoding} not supported");
         }
 
@@ -222,7 +222,7 @@ abstract class CommonStringWrapperTest extends TestCase
     public function testWordWrap($encoding, $string, $width, $break, $cut, $expected)
     {
         $wrapper = $this->getWrapper($encoding);
-        if (!$wrapper) {
+        if (! $wrapper) {
             $this->markTestSkipped("Encoding {$encoding} not supported");
         }
 
@@ -233,7 +233,7 @@ abstract class CommonStringWrapperTest extends TestCase
     public function testWordWrapInvalidArgument()
     {
         $wrapper = $this->getWrapper();
-        if (!$wrapper) {
+        if (! $wrapper) {
             $this->fail("Can't instantiate wrapper");
         }
 
@@ -287,7 +287,7 @@ abstract class CommonStringWrapperTest extends TestCase
     public function testStrPad($encoding, $input, $padLength, $padString, $padType, $expected)
     {
         $wrapper = $this->getWrapper($encoding);
-        if (!$wrapper) {
+        if (! $wrapper) {
             $this->markTestSkipped("Encoding {$encoding} not supported");
         }
 

--- a/test/StringWrapper/IconvTest.php
+++ b/test/StringWrapper/IconvTest.php
@@ -16,7 +16,7 @@ class IconvTest extends CommonStringWrapperTest
 {
     public function setUp()
     {
-        if (!extension_loaded('iconv')) {
+        if (! extension_loaded('iconv')) {
             try {
                 new Iconv('utf-8');
                 $this->fail('Missing expected Zend\Stdlib\Exception\ExtensionNotLoadedException');
@@ -35,7 +35,7 @@ class IconvTest extends CommonStringWrapperTest
             $encoding = array_shift($supportedEncodings);
         }
 
-        if (!Iconv::isSupported($encoding, $convertEncoding)) {
+        if (! Iconv::isSupported($encoding, $convertEncoding)) {
             return false;
         }
 

--- a/test/StringWrapper/IntlTest.php
+++ b/test/StringWrapper/IntlTest.php
@@ -16,7 +16,7 @@ class IntlTest extends CommonStringWrapperTest
 {
     public function setUp()
     {
-        if (!extension_loaded('intl')) {
+        if (! extension_loaded('intl')) {
             try {
                 new Intl('utf-8');
                 $this->fail('Missing expected Zend\Stdlib\Exception\ExtensionNotLoadedException');
@@ -35,7 +35,7 @@ class IntlTest extends CommonStringWrapperTest
             $encoding = array_shift($supportedEncodings);
         }
 
-        if (!Intl::isSupported($encoding, $convertEncoding)) {
+        if (! Intl::isSupported($encoding, $convertEncoding)) {
             return false;
         }
 

--- a/test/StringWrapper/MbStringTest.php
+++ b/test/StringWrapper/MbStringTest.php
@@ -16,7 +16,7 @@ class MbStringTest extends CommonStringWrapperTest
 {
     public function setUp()
     {
-        if (!extension_loaded('mbstring')) {
+        if (! extension_loaded('mbstring')) {
             try {
                 new MbString('utf-8');
                 $this->fail('Missing expected Zend\Stdlib\Exception\ExtensionNotLoadedException');
@@ -35,7 +35,7 @@ class MbStringTest extends CommonStringWrapperTest
             $encoding = array_shift($supportedEncodings);
         }
 
-        if (!MbString::isSupported($encoding, $convertEncoding)) {
+        if (! MbString::isSupported($encoding, $convertEncoding)) {
             return false;
         }
 

--- a/test/StringWrapper/NativeTest.php
+++ b/test/StringWrapper/NativeTest.php
@@ -20,7 +20,7 @@ class NativeTest extends CommonStringWrapperTest
             $encoding = array_shift($supportedEncodings);
         }
 
-        if (!Native::isSupported($encoding, $convertEncoding)) {
+        if (! Native::isSupported($encoding, $convertEncoding)) {
             return false;
         }
 

--- a/test/TestAsset/ArrayObjectIterator.php
+++ b/test/TestAsset/ArrayObjectIterator.php
@@ -8,10 +8,11 @@
  */
 
 namespace ZendTest\Stdlib\TestAsset;
+
 class ArrayObjectIterator implements \Iterator
 {
 
-    private $var = array();
+    private $var = [];
 
     public function __construct($array)
     {
@@ -43,7 +44,7 @@ class ArrayObjectIterator implements \Iterator
     public function valid()
     {
         $key = key($this->var);
-        $var = ($key !== NULL && $key !== FALSE);
+        $var = ($key !== null && $key !== false);
 
         return $var;
     }

--- a/test/TestAsset/ArrayObjectObjectVars.php
+++ b/test/TestAsset/ArrayObjectObjectVars.php
@@ -8,6 +8,7 @@
  */
 
 namespace ZendTest\Stdlib\TestAsset;
+
 class ArrayObjectObjectVars
 {
     public $public = 'prop:public';

--- a/test/TestAsset/ArraySerializable.php
+++ b/test/TestAsset/ArraySerializable.php
@@ -14,16 +14,16 @@ namespace ZendTest\Stdlib\TestAsset;
  */
 class ArraySerializable implements \Zend\Stdlib\ArraySerializableInterface
 {
-    protected $data = array();
+    protected $data = [];
 
     public function __construct()
     {
-        $this->data = array(
+        $this->data = [
             "foo" => "bar",
             "bar" => "foo",
             "blubb" => "baz",
             "quo" => "blubb"
-        );
+        ];
     }
 
     /**

--- a/test/TestAsset/TestOptionsNoStrict.php
+++ b/test/TestAsset/TestOptionsNoStrict.php
@@ -16,7 +16,9 @@ use Zend\Stdlib\AbstractOptions;
  */
 class TestOptionsNoStrict extends AbstractOptions
 {
+    // @codingStandardsIgnoreStart
     protected $__strictMode__ = false;
+    // @codingStandardsIgnoreEnd
 
     protected $testField;
 


### PR DESCRIPTION
This patch does the following:

- Ups the minimum supported PHP version to 5.6.
- Switches from php-cs-fixer to phpcs