### PR TITLE
Fix type of Message content property

### DIFF
--- a/src/Message.php
+++ b/src/Message.php
@@ -19,7 +19,7 @@ class Message implements MessageInterface
     protected $metadata = [];
 
     /**
-     * @var string
+     * @var mixed
      */
     protected $content = '';
 


### PR DESCRIPTION
Both the getter and setter imply that the `$content` property could be anything. I am not 100% sure which one is correct; albeit the PR.