### PR TITLE
Prevent extension of static classes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
         }
     },
     "require": {
-        "php": "^5.6 || ^7.0"
+        "php": "^5.6 || ^7.0",
+        "scriptfusion/static-class": "^1"
     },
     "require-dev": {
         "athletic/athletic": "~0.1",

--- a/src/ArrayUtils.php
+++ b/src/ArrayUtils.php
@@ -9,17 +9,18 @@
 
 namespace Zend\Stdlib;
 
+use ScriptFUSION\StaticClass;
 use Traversable;
 use Zend\Stdlib\ArrayUtils\MergeRemoveKey;
 use Zend\Stdlib\ArrayUtils\MergeReplaceKeyInterface;
 
 /**
  * Utility class for testing and manipulation of PHP arrays.
- *
- * Declared abstract, as we have no need for instantiation.
  */
-abstract class ArrayUtils
+final class ArrayUtils
 {
+    use StaticClass;
+
     /**
      * Compatibility Flag for ArrayUtils::filter
      */

--- a/src/ErrorHandler.php
+++ b/src/ErrorHandler.php
@@ -10,13 +10,16 @@
 namespace Zend\Stdlib;
 
 use ErrorException;
+use ScriptFUSION\StaticClass;
 
 /**
  * ErrorHandler that can be used to catch internal PHP errors
  * and convert to an ErrorException instance.
  */
-abstract class ErrorHandler
+final class ErrorHandler
 {
+    use StaticClass;
+
     /**
      * Active stack
      *

--- a/src/Glob.php
+++ b/src/Glob.php
@@ -9,11 +9,15 @@
 
 namespace Zend\Stdlib;
 
+use ScriptFUSION\StaticClass;
+
 /**
  * Wrapper for glob with fallback if GLOB_BRACE is not available.
  */
-abstract class Glob
+final class Glob
 {
+    use StaticClass;
+
     /**#@+
      * Glob constants.
      */
@@ -53,7 +57,7 @@ abstract class Glob
      * @return array
      * @throws Exception\RuntimeException
      */
-    protected static function systemGlob($pattern, $flags)
+    private static function systemGlob($pattern, $flags)
     {
         if ($flags) {
             $flagMap = [
@@ -94,7 +98,7 @@ abstract class Glob
      * @return array
      * @throws Exception\RuntimeException
      */
-    protected static function fallbackGlob($pattern, $flags)
+    private static function fallbackGlob($pattern, $flags)
     {
         if (! $flags & self::GLOB_BRACE) {
             return static::systemGlob($pattern, $flags);
@@ -175,7 +179,7 @@ abstract class Glob
      * @param  int $flags
      * @return int|null
      */
-    protected static function nextBraceSub($pattern, $begin, $flags)
+    private static function nextBraceSub($pattern, $begin, $flags)
     {
         $length  = strlen($pattern);
         $depth   = 0;

--- a/src/StringUtils.php
+++ b/src/StringUtils.php
@@ -9,29 +9,30 @@
 
 namespace Zend\Stdlib;
 
+use ScriptFUSION\StaticClass;
 use Zend\Stdlib\StringWrapper\StringWrapperInterface;
 
 /**
  * Utility class for handling strings of different character encodings
  * using available PHP extensions.
- *
- * Declared abstract, as we have no need for instantiation.
  */
-abstract class StringUtils
+final class StringUtils
 {
+    use StaticClass;
+
     /**
      * Ordered list of registered string wrapper instances
      *
      * @var StringWrapperInterface[]
      */
-    protected static $wrapperRegistry = null;
+    private static $wrapperRegistry = null;
 
     /**
      * A list of known single-byte character encodings (upper-case)
      *
      * @var string[]
      */
-    protected static $singleByteEncodings = [
+    private static $singleByteEncodings = [
         'ASCII', '7BIT', '8BIT',
         'ISO-8859-1', 'ISO-8859-2', 'ISO-8859-3', 'ISO-8859-4', 'ISO-8859-5',
         'ISO-8859-6', 'ISO-8859-7', 'ISO-8859-8', 'ISO-8859-9', 'ISO-8859-10',
@@ -45,7 +46,7 @@ abstract class StringUtils
      *
      * @var bool
      **/
-    protected static $hasPcreUnicodeSupport = null;
+    private static $hasPcreUnicodeSupport = null;
 
     /**
      * Get registered wrapper classes


### PR DESCRIPTION
Merely declaring a class `abstract` does not correctly convey intent nor prevent misuse. By marking the class `final` we prevent extension and by using the `StaticClass` trait we prevent instantiation.