### PR TITLE
Marked ArrayUtils::filter as deprecated

### DIFF
--- a/src/ArrayUtils.php
+++ b/src/ArrayUtils.php
@@ -292,12 +292,13 @@ abstract class ArrayUtils
     }
 
     /**
-     * Compatibility Method for array_filter on <5.6 systems
+     * @deprecated Since 3.2.0; use the native array_filter methods
      *
      * @param array $data
      * @param callable $callback
      * @param null|int $flag
      * @return array
+     * @throws Exception\InvalidArgumentException
      */
     public static function filter(array $data, $callback, $flag = null)
     {
@@ -308,28 +309,6 @@ abstract class ArrayUtils
             ));
         }
 
-        if (version_compare(PHP_VERSION, '5.6.0') >= 0) {
-            return array_filter($data, $callback, $flag);
-        }
-
-        $output = [];
-        foreach ($data as $key => $value) {
-            $params = [$value];
-
-            if ($flag === static::ARRAY_FILTER_USE_BOTH) {
-                $params[] = $key;
-            }
-
-            if ($flag === static::ARRAY_FILTER_USE_KEY) {
-                $params = [$key];
-            }
-
-            $response = call_user_func_array($callback, $params);
-            if ($response) {
-                $output[$key] = $value;
-            }
-        }
-
-        return $output;
+        return array_filter($data, $callback, $flag);
     }
 }


### PR DESCRIPTION
This method was implemented only for compatibility with PHP <5.6.
Library now supports only PHP 5.6+ so this method is no longer needed.
Removed functionality for PHP <5.6 and marked function as deprecated
since 3.2.0. Added suggestion to use native method `array_filter`.