### PR TITLE
Fix testCount for PHP 7.2

### DIFF
--- a/test/ArrayObjectTest.php
+++ b/test/ArrayObjectTest.php
@@ -103,8 +103,20 @@ class ArrayObjectTest extends TestCase
 
     public function testCount()
     {
+        if (version_compare(PHP_VERSION, '7.2', '>=')) {
+            $this->setExpectedException(
+                'PHPUnit_Framework_Error_Warning',
+                'Parameter must be an array or an object that implements Countable'
+            );
+        }
         $ar = new ArrayObject(new TestAsset\ArrayObjectObjectVars());
         $this->assertEquals(1, $ar->count());
+    }
+
+    public function testCountable()
+    {
+        $ar = new ArrayObject(new TestAsset\ArrayObjectObjectCount());
+        $this->assertEquals(42, $ar->count());
     }
 
     public function testExchangeArray()

--- a/test/TestAsset/ArrayObjectObjectCount.php
+++ b/test/TestAsset/ArrayObjectObjectCount.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Stdlib\TestAsset;
+
+class ArrayObjectObjectCount implements \Countable
+{
+   public function count() {
+       return 42;
+   }
+}


### PR DESCRIPTION
PHP 7.2 raise a deprecated message
  Parameter must be an array or an object that implements Countable

I think this should not be hidden (count could take care of this),
so this change declare the message as expected.

A new test is added for object which are really countable


Detected by Fedora QA with 7.2.0RC4
https://apps.fedoraproject.org/koschei/package/php-zendframework-zend-stdlib?collection=f28