### PR TITLE
Building in PHP 7.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,9 +31,8 @@ matrix:
     - php: 7
       env:
         - CS_CHECK=true
-    - php: hhvm 
-  allow_failures:
-    - php: hhvm
+    - php: 7.1
+    - php: 7.2
 
 notifications:
   irc: "irc.freenode.org#zftalk.dev"

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     },
     "require-dev": {
         "athletic/athletic": "~0.1",
-        "phpunit/PHPUnit": "~4.0",
+        "phpunit/phpunit": "~5.0",
         "zendframework/zend-coding-standard": "~1.0.0"
     },
     "extra": {
@@ -39,8 +39,8 @@
         ],
         "cs-check": "phpcs",
         "cs-fix": "phpcbf",
-        "test": "phpunit --colors=always",
-        "test-coverage": "phpunit --colors=always --coverage-clover clover.xml",
+        "test": "./vendor/bin/phpunit --colors=always",
+        "test-coverage": "./vendor/bin/phpunit --colors=always --coverage-clover clover.xml",
         "upload-coverage": "coveralls -v"
     }
 }


### PR DESCRIPTION
- Fixes broken 5.6 build by running project's PHPUnit version rather than Travis' version
- Bumps PHPUnit version to one that works in PHP 7.2
- Drops HipHop build
- Adds builds for PHP 7.1 & 7.2

Fix https://github.com/zendframework/zend-stdlib/issues/88