### PR TITLE
php 7.3 compat: continue targeting switch equaivalent to break;

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,6 +54,9 @@ matrix:
     - php: 7.2
       env:
         - DEPS=latest
+    - php: nightly
+      env:
+        - DEPS=latest
 
 before_install:
   - if [[ $TEST_COVERAGE != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Fixed
 
-- Nothing.
+- [#91](https://github.com/zendframework/zend-stdlib/pull/91) php 7.3 compatible which the behaviour of continue targeting switch equaivalent to break.
 
 ## 3.2.0 - 2018-04-30
 

--- a/src/ArrayObject.php
+++ b/src/ArrayObject.php
@@ -425,7 +425,7 @@ class ArrayObject implements IteratorAggregate, ArrayAccess, Serializable, Count
                     $this->setIteratorClass($v);
                     break;
                 case 'protectedProperties':
-                    continue;
+                    continue 2;
                 default:
                     $this->__set($k, $v);
             }

--- a/src/ArrayObject.php
+++ b/src/ArrayObject.php
@@ -425,7 +425,7 @@ class ArrayObject implements IteratorAggregate, ArrayAccess, Serializable, Count
                     $this->setIteratorClass($v);
                     break;
                 case 'protectedProperties':
-                    continue 2;
+                    break;
                 default:
                     $this->__set($k, $v);
             }


### PR DESCRIPTION
Provide a narrative description of what you are trying to accomplish:

in PHP 7.3.0-dev ( nightly )
- [x] Are you fixing a bug?
  - [x] Detail how the bug is invoked currently.
          It is inside `ArrayObject` class which the `continue` code called inside switch inside loop.
  - [x] Detail the original, incorrect behavior.
          It got error: "`E_WARNING` \"continue\" targeting switch is equivalent to \"break\". Did you mean to use \"continue 2\"?"
  - [x] Detail the new, expected behavior.
          <s>using `continue 2`</s> using break; to jump to next loop.
  - [x] Base your feature on the `master` branch, and submit against that branch.
  - [x] Add a regression test that demonstrates the bug, and proves the fix.
         without this patch, the test should failure.
  - [x] Add a `CHANGELOG.md` entry for the fix.
