### PR TITLE
Fix SplPriorityQueue::$serial not being reset after serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Fixed
 
-- Nothing.
+- [#92](https://github.com/zendframework/zend-stdlib/pull/92) Fix SplPriorityQueue::$serial not being reset after serialization.
 
 ## 3.2.0 - 2018-04-30
 

--- a/src/SplPriorityQueue.php
+++ b/src/SplPriorityQueue.php
@@ -84,7 +84,9 @@ class SplPriorityQueue extends \SplPriorityQueue implements Serializable
      */
     public function unserialize($data)
     {
+        $this->serial = PHP_INT_MAX;
         foreach (unserialize($data) as $item) {
+            $this->serial--;
             $this->insert($item['data'], $item['priority']);
         }
     }

--- a/test/SplPriorityQueueTest.php
+++ b/test/SplPriorityQueueTest.php
@@ -48,20 +48,17 @@ class SplPriorityQueueTest extends TestCase
     {
         $s = serialize($this->queue);
         $unserialized = unserialize($s);
-        $count = count($this->queue);
-        $this->assertSame(
-            $count,
-            count($unserialized),
-            'Expected count ' . $count . '; received ' . count($unserialized)
-        );
+       
+        $this->assertSame
+            
+        // assert same size
+        $this->assertSameSize($this->queue, $unserialized);
 
-        $expected = iterator_to_array($this->queue);
-        $test = iterator_to_array($unserialized);
-        $this->assertSame(
-            $expected,
-            $test,
-            'Expected: ' . var_export($expected, 1) . "\nReceived:" . var_export($test, 1)
-        );
+        // assert same values
+        $this->assertSame(iterator_to_array($this->queue), iterator_to_array($unserialized));
+
+        // assert equal
+        $this->assertEquals($this->queue, $unserialized);
     }
 
     public function testCanRetrieveQueueAsArray()

--- a/test/SplPriorityQueueTest.php
+++ b/test/SplPriorityQueueTest.php
@@ -48,7 +48,7 @@ class SplPriorityQueueTest extends TestCase
     {
         $s = serialize($this->queue);
         $unserialized = unserialize($s);
-            
+
         // assert same size
         $this->assertSameSize($this->queue, $unserialized);
 

--- a/test/SplPriorityQueueTest.php
+++ b/test/SplPriorityQueueTest.php
@@ -48,8 +48,6 @@ class SplPriorityQueueTest extends TestCase
     {
         $s = serialize($this->queue);
         $unserialized = unserialize($s);
-       
-        $this->assertSame
             
         // assert same size
         $this->assertSameSize($this->queue, $unserialized);


### PR DESCRIPTION
Provide a narrative description of what you are trying to accomplish:

- [x] Are you fixing a bug?
  - [x] Detail how the bug is invoked currently.
  - [x] Detail the original, incorrect behavior.
  - [x] Detail the new, expected behavior.
  - [x] Base your feature on the `master` branch, and submit against that branch.
  - [x] Add a regression test that demonstrates the bug, and proves the fix.
  - [x] Add a `CHANGELOG.md` entry for the fix.

The current SplPriorityQueue doesn't reset the serial property after serialization which makes it not equal to the original PriorityQueue.

```php
<?php
    use Zend\Stdlib\SplPriorityQueue as Queue;

    $queue = new Queue();
    $queue->insert('foo', 3);
    $queue->insert('bar', 4);
    $queue->insert('baz', 2);
    $queue->insert('bat', 1);
   
    $serialized = serialize($queue);
    $unserialized = unserialize($serialized);

    $serial = new ReflectionProperty(Queue::class, 'serial');
    $serial->setAccessible(true);

    if ($serial->getValue($queue) === $serial->getValue($unserialized)) {
       print 'cool !';
    } else {
       print 'oh ?';
    }
    
```

original, incorrect behavior : 
prints `oh ?`
new, correct behavior : 
prints `cool !`

