### PR TITLE
Fix PHP 7.3 warning: 

### DIFF
--- a/src/ArrayObject.php
+++ b/src/ArrayObject.php
@@ -425,7 +425,7 @@ class ArrayObject implements IteratorAggregate, ArrayAccess, Serializable, Count
                     $this->setIteratorClass($v);
                     break;
                 case 'protectedProperties':
-                    continue;
+                    break;
                 default:
                     $this->__set($k, $v);
             }


### PR DESCRIPTION
"continue" targeting switch is equivalent to "break". Did you mean to use "continue 2"?
