### PR TITLE
Replace break usage by continue 2 to remove Warning : alert

### DIFF
--- a/src/ArrayObject.php
+++ b/src/ArrayObject.php
@@ -417,15 +417,15 @@ class ArrayObject implements IteratorAggregate, ArrayAccess, Serializable, Count
             switch ($k) {
                 case 'flag':
                     $this->setFlags($v);
-                    break;
+                    continue 2;
                 case 'storage':
                     $this->exchangeArray($v);
-                    break;
+                    continue 2;
                 case 'iteratorClass':
                     $this->setIteratorClass($v);
-                    break;
+                    continue 2;
                 case 'protectedProperties':
-                    break;
+                    continue 2;
                 default:
                     $this->__set($k, $v);
             }


### PR DESCRIPTION
Remove warning alert cause of using break in a switch in a foreach
Alert appears by using PHP 7.3
