### PR TITLE
[ERROR] Update ArrayObject.php in 2.7.7

### DIFF
--- a/src/ArrayObject.php
+++ b/src/ArrayObject.php
@@ -423,7 +423,7 @@ class ArrayObject implements IteratorAggregate, ArrayAccess, Serializable, Count
                     $this->setIteratorClass($v);
                     break;
                 case 'protectedProperties':
-                    continue;
+                    continue 2;
                 default:
                     $this->__set($k, $v);
             }


### PR DESCRIPTION
Provide a narrative description of what you are trying to accomplish:

- Are you fixing a bug?
  - Detail how the bug is invoked currently.

  Just install zendframework and get error with this.

- Is this related to quality assurance?
I using a old php program this throw an error, and not is fixed in 2.7.7