### PR TITLE
Backport d0cd1d04 to 2.7 branch for PHP 7.3 compatibility

### DIFF
--- a/src/ArrayObject.php
+++ b/src/ArrayObject.php
@@ -423,7 +423,7 @@ class ArrayObject implements IteratorAggregate, ArrayAccess, Serializable, Count
                     $this->setIteratorClass($v);
                     break;
                 case 'protectedProperties':
-                    continue;
+                    break;
                 default:
                     $this->__set($k, $v);
             }


### PR DESCRIPTION
This will get rid of a new warning that's caused in PHP 7.3 by the code below.

`Warning: "continue" targeting switch is equivalent to "break". Did you mean to use "continue 2"?`

This has already been fixed for zend-stdlib 3.x but I need to run a legacy project with stdlib 2.7 on PHP 7.3.

No backwards compatibility issues, as the correct way to write said code has always been "break" at this point.