### PR TITLE
Replace continue with a break

### DIFF
--- a/src/ArrayObject.php
+++ b/src/ArrayObject.php
@@ -423,7 +423,7 @@ class ArrayObject implements IteratorAggregate, ArrayAccess, Serializable, Count
                     $this->setIteratorClass($v);
                     break;
                 case 'protectedProperties':
-                    continue;
+                    break;
                 default:
                     $this->__set($k, $v);
             }


### PR DESCRIPTION
Replace continue in switch to resolve a PHP 7.3 Warning.
> Warning: "continue" targeting switch is equivalent to "break".